### PR TITLE
Update docs for async usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,27 @@ Easily query the Deezer API from you Python code. The data returned by the Deeze
 API is mapped to python resources:
 
 ```pycon
->>> client = deezer.Client()
->>> client.get_album(680407).title
+>>> async with deezer.Client() as client:
+...     album = await client.get_album(680407)
+...     album.title
 'Monkey Business'
+```
+
+### Running asynchronous code
+
+You can execute asynchronous snippets using the event loop of your choice. Here
+is how to run the above example with ``asyncio``:
+
+```python
+import asyncio
+import deezer
+
+async def main():
+    async with deezer.Client() as client:
+        album = await client.get_album(680407)
+        print(album.title)
+
+asyncio.run(main())
 ```
 
 Ready for more? Look at our whole [documentation](http://deezer-python.readthedocs.io/)

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -9,23 +9,23 @@ For endpoints returning a paginated response, the list of items are wrapped in a
 The class is an iterator, meaning that you can go through instances in the list with a for loop, or by calling `next()` to get the following item:
 
 ```python
-artist_albums = artist.get_albums()
+artist_albums = await artist.get_albums()
 
 # Iterable style
-for album in artist_albums:
+async for album in artist_albums:
     print(album.title)
 
 # Iterator
-album_1 = next(artist_albums)
-album_2 = next(artist_albums)
-album_3 = next(artist_albums)
+album_1 = await anext(artist_albums)
+album_2 = await anext(artist_albums)
+album_3 = await anext(artist_albums)
 ```
 
 This will take care or fetching extra pages if needed. Once all the elements have been fetched, no further network calls will happen. This will work if you iterate over the same paginated response again:
 
 ```python
 # No API calls: artist_albums is reused from above
-for album in artist_albums:
+async for album in artist_albums:
     print(album.title)
 ```
 
@@ -33,7 +33,7 @@ However, API calls would be repeated if you get a fresh paginated response again
 
 ```python
 # New API calls: artist.get_albums() returns a fresh paginated list
-for album in artist.get_albums():
+async for album in await artist.get_albums():
     print(album.title)
 ```
 


### PR DESCRIPTION
## Summary
- show `async with` example in README
- explain how to run async snippets via `asyncio`
- update pagination docs to use `async for`

## Testing
- `pre-commit run --files README.md docs/pagination.md` *(fails: certificate verify failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'environs')*

------
https://chatgpt.com/codex/tasks/task_e_686ec8211e508332ade762c2e6049b77